### PR TITLE
fix: filtering of test results

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-rust-test-adapter",
   "displayName": "Rust Test Explorer",
   "description": "View and run your Rust tests in the Sidebar of Visual Studio Code",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "license": "MIT",
   "preview": true,
   "private": true,

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -58,7 +58,7 @@ export const runTestSuite = async (
     _config: IConfiguration
 ) => new Promise<TestEvent[]>(async (resolve, reject) => {
     try {
-        const { packageName, testSpecName, targets } = testSuiteNode;
+        const { packageName, testSpecName, targets, id } = testSuiteNode;
         const results = await Promise.all(targets.map(async target => {
             const testIdPrefix = `${packageName}::${target.targetName}::${target.targetType}`;
             const params = <ICargoTestExecutionParameters> {
@@ -68,7 +68,7 @@ export const runTestSuite = async (
                 targetWorkspace: workspaceRootDir
             };
             const output = await runCargoTestsForPackageTargetWithPrettyFormat(params);
-            return parseTestCaseResultPrettyOutput(testIdPrefix, output);
+            return parseTestCaseResultPrettyOutput(testIdPrefix, output).filter(e => e.test.toString().startsWith(id));
         }));
 
         resolve([].concat(...results));

--- a/test/unit/test-runner.ts
+++ b/test/unit/test-runner.ts
@@ -160,10 +160,16 @@ suite('testRunner Tests:', () => {
         });
 
         test('Should return correct result on successful execution and parse', async () => {
-            const result = await runTestSuite(testSuite, workspaceDir, logStub, null);
-            // The stubs are currently configured to return the same 2 events on each call, so
-            // the expected value would be an array of 4 items, the repeated 2 events for each of the 2 targets.
-            assert.deepEqual(result, [ expTestEvent, expTestEvent2, expTestEvent, expTestEvent2 ]);
+            const firstTest = buildTestEvent('passed', 'swanson::bin::foo::test_one');
+            const secondTest = buildTestEvent('passed', 'swanson::bin::foo::test_two');
+            const thirdTest = buildTestEvent('passed', 'swanson::bin::bar::foo::test_baz');
+            const suite = JSON.parse(JSON.stringify(testSuite));
+            suite.id = 'swanson::bin::foo';
+            parseTestCaseResultPrettyOutputStub.onFirstCall().callsFake(() => [ firstTest, thirdTest ]);
+            parseTestCaseResultPrettyOutputStub.onSecondCall().callsFake(() => [ secondTest ]);
+
+            const result = await runTestSuite(suite, workspaceDir, logStub, null);
+            assert.deepEqual(result, [ firstTest, secondTest ]);
         });
     });
 });


### PR DESCRIPTION
Resolves #56 (via the first solution). 

This change fixes the "bug" of unspecified tests being executed and having the results shown due to limitations in `libtest`'s filtering support (which currently only provides for exact and "contains" matches). 

I'm still planning on trying to get the underlying upstream issue resolved in libtest via filtering support for a regex and/or a "starts with" but this will handle things on our end